### PR TITLE
Update status check since update 2025.1

### DIFF
--- a/utils/domoticz.js
+++ b/utils/domoticz.js
@@ -5,6 +5,8 @@ const {debugLogger} = require('./logger')
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"; //self signed ssl certificate
 const STATUS_COMMAND = "json.htm?type=devices&rid=0";
+const STATUS_COMMAND_20232 = "json.htm?type=devices&rid=0";
+const VERSION = "json.htm?type=command&param=getversion";
 
 function extractDomoticzUrlData (request) {
   let domoticzUrlData = {domain:null,proto:"http"};
@@ -53,7 +55,6 @@ function promiseHttpRequest (options) {
     })
 }
 
-
 exports.checkDomoticz = async (userData)=>{
 	console.log("check");
 	const { domain,proto } = extractDomoticzUrlData(userData.domoticzHost);
@@ -66,7 +67,7 @@ exports.checkDomoticz = async (userData)=>{
     proto:proto,
     hostname: domain,
     port: domoticzPort,
-    path: '/'+STATUS_COMMAND,
+    path: '/'+VERSION,
     method: 'GET',
     headers: {
       'Authorization': basicAuth,

--- a/utils/domoticz.js
+++ b/utils/domoticz.js
@@ -6,7 +6,7 @@ const {debugLogger} = require('./logger')
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"; //self signed ssl certificate
 const STATUS_COMMAND = "json.htm?type=devices&rid=0";
 const STATUS_COMMAND_20232 = "json.htm?type=devices&rid=0";
-const VERSION = "json.htm?type=command&param=getversion";
+const VERSION_COMMAND = "json.htm?type=command&param=getversion";
 
 function extractDomoticzUrlData (request) {
   let domoticzUrlData = {domain:null,proto:"http"};
@@ -67,7 +67,7 @@ exports.checkDomoticz = async (userData)=>{
     proto:proto,
     hostname: domain,
     port: domoticzPort,
-    path: '/'+VERSION,
+    path: '/'+VERSION_COMMAND,
     method: 'GET',
     headers: {
       'Authorization': basicAuth,


### PR DESCRIPTION
Suite à la MAJ 2025.1 les appels jeon.htm?type=devices ne fonctionnent plus. ils avaient été oublié avec la MAJ de la version 2023.2
cf https://wiki.domoticz.com/Domoticz_API/JSON_URL%27s

