### PR TITLE
fix: handle register errors gracefully instead of re-throwing

### DIFF
--- a/app.js
+++ b/app.js
@@ -249,13 +249,15 @@ app.post('/register', async function(req, res) {
     prodLogger("creating data ");
     debugLogger(user.id)//TODO : understand why NULL
     const user_data = await createData(user.id);
-    //create session 
+    //create session
     req.session = {uid:user.id,...INIT_MESSAGE};
 
     return res.redirect("./account");
   }catch(e)
   {
-    throw e;
+    prodLogger(e);
+    error = "An error occurred during registration";
+    return res.redirect(util.format('/register?error=%s', error));
   }
   
 });


### PR DESCRIPTION
Replaced throw e with a proper redirect to /register with an error message, preventing unhandled async rejections that caused Traefik to return 502 Bad Gateway.