### PR TITLE
feat: add /health route

### DIFF
--- a/app.js
+++ b/app.js
@@ -381,6 +381,40 @@ app.get('/profile', authenticate(app.oauth,{scope:'profile'}), function(req,res)
 });
 
 
+let healthCache = null;
+let healthCacheAt = 0;
+const HEALTH_CACHE_TTL = 10000;
+
+app.get('/health', async function (req, res) {
+  const now = Date.now();
+  if (healthCache && (now - healthCacheAt) < HEALTH_CACHE_TTL) {
+    return res.status(healthCache.status).json(healthCache.body);
+  }
+
+  const mem = process.memoryUsage();
+  let dbOk = false;
+  try {
+    const {getDatabase} = require('./utils/database');
+    await getDatabase().query('SELECT 1');
+    dbOk = true;
+  } catch (e) {
+    prodLogger('health db check failed: ' + e.message);
+  }
+
+  const body = {
+    status: dbOk ? 'ok' : 'degraded',
+    uptime: Math.floor(process.uptime()),
+    memory_mb: Math.round(mem.rss / 1024 / 1024),
+    db: dbOk ? 'ok' : 'error',
+  };
+  const status = dbOk ? 200 : 503;
+
+  healthCache = {status, body};
+  healthCacheAt = now;
+
+  return res.status(status).json(body);
+});
+
 app.get('/', function (req, res) {
   res.sendFile(path.join(__dirname+'/views/index.html'));
 })


### PR DESCRIPTION
## Summary
- `GET /health` retourne le statut de l'app, uptime, mémoire et connectivité DB
- Vérification DB via `SELECT 1` (requête minimale)
- Résultat mis en cache 10s pour éviter de marteler la DB en cas d'appels répétés
- Retourne `200` si tout est OK, `503` si la DB est inaccessible

## Exemple de réponse
```json
{ "status": "ok", "uptime": 3600, "memory_mb": 85, "db": "ok" }
```

## Test plan
- [x] CI passe
- [x] `GET /health` retourne 200 avec DB connectée
- [x] `GET /health` retourne 503 si DB inaccessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)