### PR TITLE
fix: set refresh token lifetime to 1 year

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,7 +15,7 @@ var helmet = require('helmet');
 const authenticate = require('./authenticate')
 const {checkDomoticz} = require('./utils/domoticz')
 const {encodeTokenFor,cryptPassword,encrypt,decrypt,generateAuthCode} = require('./utils/security');
-const {ALEXA_TOKEN_FORMAT,COOKIE_SECRET,TOKEN_EXPIRES_DELAY,NOT_CHANGED_PASSWORD} = require('./utils/constants')
+const {ALEXA_TOKEN_FORMAT,COOKIE_SECRET,TOKEN_EXPIRES_DELAY,REFRESH_TOKEN_EXPIRES_DELAY,NOT_CHANGED_PASSWORD} = require('./utils/constants')
 const {saveAuthorizationCode} = require("./oauthapi")
 const {
         checkExistsEmail,
@@ -70,7 +70,7 @@ app.oauth =  new oAuth2Server({
 app.post('/oauth/token', function(req,res,next){
     var request = new Request(req);
     var response = new Response(res);
-    const options = {accessTokenLifetime:TOKEN_EXPIRES_DELAY};
+    const options = {accessTokenLifetime:TOKEN_EXPIRES_DELAY, refreshTokenLifetime:REFRESH_TOKEN_EXPIRES_DELAY};
     prodLogger('/oauth/token');
     app.oauth
       .token(request,response,options)

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -12,6 +12,7 @@ exports.PRIVATEKEY = process.env.PRIVATEKEY;
 exports.PUBLICKEY = process.env.PUBLICKEY;
 
 exports.TOKEN_EXPIRES_DELAY = 86400;
+exports.REFRESH_TOKEN_EXPIRES_DELAY = 60 * 60 * 24 * 365;
 
 exports.ALEXA_TOKEN_FORMAT = "alexa";
 exports.DEFAULT_TOKEN_FORMAT = "default";


### PR DESCRIPTION
## Summary
- The `/oauth/token` handler only passed `accessTokenLifetime` to `oauth2-server`, so `refreshTokenLifetime` silently fell back to the library default of **14 days**.
- Users who did not trigger Alexa within that window saw their refresh token expire and had to re-link the skill (issue not visible to active users because each refresh issues a new 14-day token, indefinitely rolling the window).
- Set `refreshTokenLifetime` to **1 year** via a new `REFRESH_TOKEN_EXPIRES_DELAY` constant so an inactive user can still refresh transparently.

## Test plan
- [x] `npm test` (`node --check` on all source files) passes.
- [ ] Smoke test: link the Alexa skill, then call `/oauth/token` with `grant_type=refresh_token` and verify the returned token works and that the DB row for the new token has `refresh_token_expires_on` ~1 year in the future.
- [ ] Confirm the `oauth_tokens.refresh_token_expires_on` column is a `DATETIME` (not a `TIMESTAMP` capped at 2038) — non-blocking but worth checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)